### PR TITLE
Fixed pagination next and previous button hovering issue

### DIFF
--- a/lib/src/components/pagination.dart
+++ b/lib/src/components/pagination.dart
@@ -606,7 +606,7 @@ class _NavButton extends StatelessWidget {
             mouseCursor: enabled ? null : SystemMouseCursors.forbidden,
             onTap: enabled ? onTap : null,
             child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: 7, horizontal: 14),
+              padding: const EdgeInsets.all(7),
               child: Center(
                 child: iconFirst
                     ? widget.previousButtonWidget ?? defaultNavButton()


### PR DESCRIPTION
On hovering next button and previous button in pagination, hovering was not circular, so added same padding all around for those buttons.